### PR TITLE
[Fix] Trainer interface error when eval minicpm-v-2.6

### DIFF
--- a/finetune/trainer.py
+++ b/finetune/trainer.py
@@ -150,7 +150,7 @@ class CPMTrainer(Trainer):
                 else:
                     loss = None
                     with self.compute_loss_context_manager():
-                        outputs = model(**inputs)
+                        outputs = model(data=inputs)
                     if isinstance(outputs, dict):
                         logits = tuple(
                             v for k, v in outputs.items() if k not in ignore_keys


### PR DESCRIPTION
The interface to minicpm v2.6 is data, **inputs can't reasonably get data, when the model.eval mode is turned on, there will be a problem of not finding the input data, after experimenting to pass the data in like the training process above. 
```
def forward(self, data, **kwargs):
```
This interface is in modeling of minicpm v2.6, and the function in trainer does not align with it.