### PR TITLE
deepspeed 配置文件bug

### DIFF
--- a/finetune/ds_config_zero2.json
+++ b/finetune/ds_config_zero2.json
@@ -22,14 +22,6 @@
         }
     },
 
-    "scheduler": {
-        "type": "WarmupLR",
-        "params": {
-            "warmup_min_lr": "auto",
-            "warmup_max_lr": "auto",
-            "warmup_num_steps": "auto"
-        }
-    },
 
     "zero_optimization": {
         "stage": 2,

--- a/finetune/ds_config_zero3.json
+++ b/finetune/ds_config_zero3.json
@@ -21,14 +21,6 @@
         }
     },
 
-    "scheduler": {
-        "type": "WarmupLR",
-        "params": {
-            "warmup_min_lr": "auto",
-            "warmup_max_lr": "auto",
-            "warmup_num_steps": "auto"
-        }
-    },
 
     "zero_optimization": {
         "stage": 3,


### PR DESCRIPTION
bug原因：预热阶段结束之后，学习率一直维持一个数值并没有按照余弦退火算法降低学习率。
经过排查，发现ds_config_zero2.json文件中写了scheduler之后，deepspeed.py的deepspeed_optim_sched函数代码逻辑进入了if里面，没有进入else，触发不了余弦退火，如下图所示
![image](https://github.com/user-attachments/assets/a747ee93-bbc0-463d-bb6d-01c5d57c321a)
删除之后可以余弦退火降低学习率，如图所示
![image](https://github.com/user-attachments/assets/1d49a7db-5679-4239-8d85-2bafd0a0d126)

