### PR TITLE
Update requirements_o2.6.txt to resolve TypeError during chatbot startup.

### DIFF
--- a/requirements_o2.6.txt
+++ b/requirements_o2.6.txt
@@ -20,3 +20,4 @@ fastapi
 uvicorn
 gradio==4.44.1
 http://thunlp.oss-cn-qingdao.aliyuncs.com/multi_modal/never_delete/modelscope_studio-0.4.0.9-py3-none-any.whl
+pydantic==2.10.6


### PR DESCRIPTION
### Summary
- Resolved a `TypeError` encountered during the startup of the ChatBot Demo.
- Added version constraints for `pydantic` in the `requirements.txt` file to ensure dependency stability.

### Details
1. **Background**:
   - During the startup of the ChatBot Demo, a `TypeError` occurred due to incompatible versions of certain dependencies.
   - Investigation revealed that the issue was related to the `pydantic` library, where specific features were not functioning correctly in certain versions.

2. **Solution**:
   - Added version constraints for `pydantic` in the `requirements.txt` file to ensure compatibility.
   - Update: ``` pydantic==2.10.6 ```
   - By specifying the version, we avoid runtime errors caused by inconsistent dependency versions.

3. **Testing Verification**:
   - Reinstalled dependencies locally and restarted the ChatBot Demo to confirm the issue was resolved.
   - Verified that all functionalities work as expected without any additional errors.