### PR TITLE
fix: rename evaluation_strategy to eval_strategy in finetune script

### DIFF
--- a/finetune/finetune_lora.sh
+++ b/finetune/finetune_lora.sh
@@ -53,7 +53,7 @@ torchrun $DISTRIBUTED_ARGS finetune.py  \
     --per_device_train_batch_size 1 \
     --per_device_eval_batch_size 1 \
     --gradient_accumulation_steps 1 \
-    --evaluation_strategy "steps" \
+    --eval_strategy "steps" \
     --save_strategy "steps" \
     --save_steps 1000 \
     --save_total_limit 10 \


### PR DESCRIPTION
## Summary
Rename `evaluation_strategy` to `eval_strategy` in `finetune/finetune_lora.sh` to fix the deprecation warning from transformers.

## Changes
- `finetune/finetune_lora.sh`: Changed `--evaluation_strategy` to `--eval_strategy`

## Context
The `evaluation_strategy` argument was renamed to `eval_strategy` in the transformers library. Using the old name causes a deprecation warning.

Fixes #1045