### PR TITLE
fix(docs): correct LLM_TYPE for MiniCPM-V-4 from 'llama' to 'llama3'

### DIFF
--- a/finetune/finetune_ds.sh
+++ b/finetune/finetune_ds.sh
@@ -13,7 +13,7 @@ MODEL="openbmb/MiniCPM-o-2_6"
 DATA="path/to/trainging_data"
 EVAL_DATA="path/to/test_data"
 
-# if use openbmb/MiniCPM-V-2, please set LLM_TYPE=minicpm, if use openbmb/MiniCPM-Llama3-V-2_5, please set LLM_TYPE="llama3",
+# if use openbmb/MiniCPM-V-2, please set LLM_TYPE=minicpm, if use openbmb/MiniCPM-Llama3-V-2_5 or MiniCPM-V-4, please set LLM_TYPE="llama3",
 # if use openbmb/MiniCPM-o-2_6 or openbmb/MiniCPM-V-2_6, please set LLM_TYPE=qwen
 LLM_TYPE="qwen" 
 MODEL_MAX_Length=2048 # if conduct multi-images sft, please set MODEL_MAX_Length=4096

--- a/finetune/finetune_lora.sh
+++ b/finetune/finetune_lora.sh
@@ -12,7 +12,7 @@ MODEL="openbmb/MiniCPM-o-2_6"
 # See the section for finetuning in README for more information.
 DATA="path/to/trainging_data"
 EVAL_DATA="path/to/test_data"
-# if use openbmb/MiniCPM-V-2, please set LLM_TYPE=minicpm, if use openbmb/MiniCPM-Llama3-V-2_5, please set LLM_TYPE="llama3",
+# if use openbmb/MiniCPM-V-2, please set LLM_TYPE=minicpm, if use openbmb/MiniCPM-Llama3-V-2_5 or MiniCPM-V-4, please set LLM_TYPE="llama3",
 # if use openbmb/MiniCPM-o-2_6 or openbmb/MiniCPM-V-2_6, please set LLM_TYPE=qwen
 LLM_TYPE="qwen"   
 MODEL_MAX_Length=2048 # if conduct multi-images sft, please set MODEL_MAX_Length=4096

--- a/finetune/readme.md
+++ b/finetune/readme.md
@@ -99,7 +99,7 @@ Full-parameter parameter finetuning requires updating all parameters of LLM in t
 MODEL="MiniCPM-o-2_6" # or "openbmb/MiniCPM-V-2_6", "openbmb/MiniCPM-Llama3-V-2_5", "openbmb/MiniCPM-V-2"
 DATA="path/to/training_data.json"
 EVAL_DATA="path/to/test_data.json"
-LLM_TYPE="qwen" # llama for MiniCPM-V-4, minicpm for MiniCPM-V-2, llama3 for MiniCPM-Llama3-V-2_5, qwen for MiniCPM-o-2_6/MiniCPM-V-2_6
+LLM_TYPE="qwen" # llama3 for MiniCPM-V-4, minicpm for MiniCPM-V-2, llama3 for MiniCPM-Llama3-V-2_5, qwen for MiniCPM-o-2_6/MiniCPM-V-2_6
 ```
 
 To launch your training, run the following script:


### PR DESCRIPTION
## Summary

- Fix incorrect `LLM_TYPE` value in finetune documentation and shell scripts for MiniCPM-V-4
- The docs stated `LLM_TYPE="llama"`, but `dataset.py` only handles `"llama3"`, `"qwen"`, and defaults to `"minicpm"` — there is no `"llama"` handler
- Users following the docs would silently get wrong tokenization (minicpm-style instead of llama3-style)

## Changes

- `finetune/readme.md`: `llama` → `llama3` for MiniCPM-V-4
- `finetune/finetune_ds.sh`: Added `MiniCPM-V-4` to the `llama3` comment
- `finetune/finetune_lora.sh`: Same as above

Fixes #1049

## Test plan

- [x] Verified `dataset.py:conversation_to_ids()` only handles `"llama3"`, `"qwen"`, and default `"minicpm"`
- [x] Confirmed upstream `readme.md` still has the incorrect `"llama"` value
- [x] Docs now match the code behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)