### PR TITLE
[Fix] conversation_to_ids: truncation guard crashes with "'list' object has no attribute 'shape'" (#581)

### DIFF
--- a/finetune/dataset.py
+++ b/finetune/dataset.py
@@ -144,10 +144,10 @@ def conversation_to_ids(conversation, tokenizer, llm_type=None, new_schema=False
 
     ids = torch.from_numpy(np.hstack(input_ids, dtype=np.int32))
     context = torch.from_numpy(np.hstack(context, dtype=np.int8))
-    if input_ids.shape[-1] > max_length:
+    if ids.shape[-1] > max_length:
         ids =ids[:max_length]
         context = context[:max_length]
-        logger.warning(f"The input length ({input_ids.shape[-1]}) exceeds the model's maximum length ({max_length}), so it has been truncated")
+        logger.warning(f"The input length ({ids.shape[-1]}) exceeds the model's maximum length ({max_length}), so it has been truncated")
     
     if torch.all(context):
         logger.error("No tokens available to compute loss.")


### PR DESCRIPTION
## Motivation

Finetuning crashes on any sample longer than `max_length` with `AttributeError: 'list' object has no attribute 'shape'`, reported in #581 (and #578). The bug is still present on current `main` (`8a2db68`).

## Root cause

In `finetune/dataset.py`, `conversation_to_ids()` hstacks the per-segment arrays into the tensor `ids`:

```python
ids = torch.from_numpy(np.hstack(input_ids, dtype=np.int32))
```

but the over-length guard still inspects `input_ids`, which is the raw Python list returned by `conversation_to_ids_minicpm/llama3/qwen2` and has no `.shape`:

```python
if input_ids.shape[-1] > max_length:                                   # line 147
    ids = ids[:max_length]
    context = context[:max_length]
    logger.warning(f"The input length ({input_ids.shape[-1]}) ...")     # line 150
```

So instead of truncating and warning, the run aborts the moment a tokenized sample exceeds `max_length` (default 2048).

## Modifications

`finetune/dataset.py`: use the `ids` tensor in both the guard (line 147) and the warning message (line 150). Two-token change; the only behavioral effect is that the intended truncation path now works.

## Duplicate-check

- Track A — open PRs referencing the issue:
  ```
  gh api "search/issues?q=repo:OpenBMB/MiniCPM-V+is:pr+581+in:body"  ->  no open PR
  ```
  Other open PRs touching `finetune/` do not touch this block: #1088 (docs), #1010 (`trainer.py`), #281 (`__len__`/`data_collator`).
- Prior PR #579 proposed a partial fix (line 147 only) but was closed unmerged by its author; line 150 still carries the identical bug.
- Track B — issue thread has no open/in-progress claim.
